### PR TITLE
Configure CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,20 @@
 name: Lint and Test Charts
 
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    # https://crontab.guru/#20_4_*_*_0
+    - cron: "20 4 * * 0"
 
 jobs:
   lint-test:
     runs-on: ubuntu-latest
     env:
-      CT_TARGET_BRANCH: ${{ github.base_ref }}
+      CT_TARGET_BRANCH: ${{ github.base_ref || 'main' }}
+      CT_ALL: ${{ github.event_name != 'pull_request' && 'true' || 'false'  }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -35,13 +43,13 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        if: steps.list-changed.outputs.changed == 'true'
+        if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'
         run: ct lint --config ct.yaml
 
       - name: Create kind cluster
-        if: steps.list-changed.outputs.changed == 'true'
+        if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'
         uses: helm/kind-action@v1.7.0
 
       - name: Run chart-testing (install)
-        if: steps.list-changed.outputs.changed == 'true'
+        if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'
         run: ct install --config ct.yaml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,47 @@
+name: Lint and Test Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    env:
+      CT_TARGET_BRANCH: ${{ github.base_ref }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.12.1
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.4.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config ct.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct lint --config ct.yaml
+
+      - name: Create kind cluster
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: helm/kind-action@v1.7.0
+
+      - name: Run chart-testing (install)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct install --config ct.yaml

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,5 @@
+# See https://github.com/helm/chart-testing#configuration
+chart-dirs:
+  - charts
+chart-repos:
+  - bitnami=https://charts.bitnami.com/bitnami


### PR DESCRIPTION
Uses [chart-testing](https://github.com/helm/chart-testing) to integration-test changed charts in a PR.

It also runs a full test after merge and every week as a nightly check (in case some dependencies have broken).

---

I tested this inside of this PR, by temporarily running chart-testing with the `--all` flag, so even if the action is a noop right now, i'm sure it will work for PRs that make chart changes.