### PR TITLE
Bump helm version when updating sub dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,13 @@
   "extends": [
     "config:base",
     "regexManagers:helmChartYamlAppVersions"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": [
+        "helmv3"
+      ],
+      "bumpVersion": "patch"
+    }
   ]
 }


### PR DESCRIPTION
This makes renovate automatically increase the Chart version (patch segment) when a helm dependency is updated.

This currently does not work for updates of the `appVersion` because of limitations of renovate.